### PR TITLE
FOR_KOTOENCODER定義時にコンパイルが通るようにする

### DIFF
--- a/scff-dsf/base/scff-output-pin.cc
+++ b/scff-dsf/base/scff-output-pin.cc
@@ -134,7 +134,7 @@ HRESULT SCFFOutputPin::GetMediaType(int position, CMediaType *media_type) {
   video_info->bmiHeader.biCompression   = MAKEFOURCC('I', '4', '2', '0');
   video_info->bmiHeader.biBitCount      = 12;
   data_size =
-      scff_imaging::Utilities::CalcDataSize(
+      scff_imaging::Utilities::CalculateDataSize(
           scff_imaging::kI420,
           video_info->bmiHeader.biWidth,
           video_info->bmiHeader.biHeight);


### PR DESCRIPTION
リネーム漏れっぽい箇所を修正しました。
